### PR TITLE
feat: adds base client with gql configuration + API key validation

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,6 @@
+{
+  "editor.tabSize": 4,
+  "python.linting.pylintEnabled": false,
+  "python.linting.enabled": true,
+  "python.linting.pycodestyleEnabled": true
+}

--- a/noloco/exceptions.py
+++ b/noloco/exceptions.py
@@ -1,0 +1,22 @@
+class NolocoAccountApiKeyError(Exception):
+    def __init__(self, project_name, error):
+        super().__init__(
+            'Your account API key did not authenticate for portal '
+            f'{project_name}')
+        self.project_name = project_name
+        self.error = error
+
+
+class NolocoProjectApiKeyError(Exception):
+    def __init__(self, project_name, error):
+        super().__init__(
+            'We could not validate the API client we setup for portal '
+            f'{project_name}')
+        self.project_name = project_name
+        self.error = error
+
+
+class NolocoUnknownError(Exception):
+    def __init__(self, error):
+        super().__init__('Something went wrong!')
+        self.error = error

--- a/noloco/noloco.py
+++ b/noloco/noloco.py
@@ -1,0 +1,54 @@
+from exceptions import NolocoAccountApiKeyError, NolocoProjectApiKeyError, \
+    NolocoUnknownError
+from gql import Client, gql
+from gql.transport.aiohttp import AIOHTTPTransport
+from gql.transport.exceptions import TransportQueryError
+import queries
+import pydash
+
+
+BASE_URL = 'https://api.nolocolocal.io'
+
+
+class Noloco:
+    def __init__(self, account_api_key, portal_name):
+        self.project_name = portal_name
+
+        account_transport = AIOHTTPTransport(
+            url=BASE_URL, headers={'Authorization': account_api_key})
+        self.account_client = Client(
+            transport=account_transport,
+            fetch_schema_from_transport=True)
+
+        try:
+            project_api_keys_query_result = self.account_client.execute(
+                gql(queries.project_api_keys_query),
+                variable_values={'projectId': portal_name})
+            project_api_key = pydash.get(
+                project_api_keys_query_result,
+                'project.apiKeys.project')
+            self.project_id = pydash.get(
+                project_api_keys_query_result, 'project.id')
+        except TransportQueryError as err:
+            raise NolocoAccountApiKeyError(self.project_name, err)
+        except Exception as err:
+            raise NolocoUnknownError(err)
+
+        try:
+            validate_api_keys_query_result = self.account_client.execute(
+                gql(queries.validate_api_keys_query),
+                variable_values={'projectToken': project_api_key})
+            self.user_id = pydash.get(
+                validate_api_keys_query_result,
+                'validateApiKeys.user.id')
+        except TransportQueryError as err:
+            raise NolocoProjectApiKeyError(self.project_name, err)
+        except Exception as err:
+            raise NolocoUnknownError(err)
+
+        project_transport = AIOHTTPTransport(
+            url=f'{BASE_URL}/data/{self.project_name}',
+            headers={'Authorization': project_api_key})
+        self.project_client = Client(
+            transport=project_transport,
+            fetch_schema_from_transport=True)

--- a/noloco/queries.py
+++ b/noloco/queries.py
@@ -1,0 +1,29 @@
+project_api_keys_query = '''
+  query ($projectId: String!) {
+    project(projectId: $projectId) {
+      id
+      name
+      apiKeys {
+        user
+        project
+        __typename
+      }
+      __typename
+    }
+  }
+'''
+
+
+validate_api_keys_query = '''
+  query ($projectToken: String!) {
+    validateApiKeys(projectToken: $projectToken) {
+      user {
+        id
+        email
+        __typename
+      }
+      projectName
+      __typename
+    }
+  }
+'''

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,5 @@
+autopep8
+gql[all]
+pycodestyle
+pydash
 sphinx


### PR DESCRIPTION
This code review adds a barebones client we can use to hit GraphQL.

I am pulling in a dependency on [gql](https://github.com/graphql-python/gql) which seems to be the [most supported Python GraphQL client](https://graphql.org/code/#python) and additionally [supports functionality we need](https://gql.readthedocs.io/) such as file uploads.

Given I had forgotten to add a linter before, I'm adding a `pep8` compliant linter to the project now. I'm also adding `autopep8` which can automate the formatting of code. Additionally I'm adding some project-specific VSCode settings as for instance indentation length will be different than our JS code.

The bare bones client is pretty self-explanatory, you pass in an account API key and project name and the constructor will then call the API to fetch your project's API key, we then setup both an account and project API client as well as validating the project API key returned from the server.

---
*Testing*

I tested this under different success conditions and verified the client is set up as expected.

If the account API key is incorrect, we wrap the underlying transport query exception in our own exception to explain what is wrong:

![image](https://user-images.githubusercontent.com/6977616/156752129-bf818be6-2f08-4370-a3b1-7ef9b04435f1.png)

If we cannot validate the project API key we fetched then we indicate this to the user:

![image](https://user-images.githubusercontent.com/6977616/156752291-bf0a1487-c51e-4ac8-9fa8-40b79ef4110c.png)

---
@noloco-io/engineering 