### PR TITLE
fix: makes all internal imports absolute and cleans up multi-line imports

### DIFF
--- a/noloco/noloco.py
+++ b/noloco/noloco.py
@@ -1,13 +1,21 @@
-from exceptions import NolocoAccountApiKeyError, \
-    NolocoProjectApiKeyError, NolocoUnknownError
 from gql import Client, gql
 from gql.transport.aiohttp import AIOHTTPTransport
 from gql.transport.exceptions import TransportQueryError
-from queries import PROJECT_API_KEYS_QUERY, PROJECT_DATA_TYPES_QUERY, \
-    QueryBuilder, VALIDATE_API_KEYS_QUERY
+from noloco.exceptions import (
+    NolocoAccountApiKeyError,
+    NolocoProjectApiKeyError,
+    NolocoUnknownError)
+from noloco.queries import (
+    PROJECT_API_KEYS_QUERY,
+    PROJECT_DATA_TYPES_QUERY,
+    QueryBuilder,
+    VALIDATE_API_KEYS_QUERY)
+from noloco.utils import (
+    collection_args,
+    find_data_type_by_name,
+    gql_args,
+    unique_args)
 from pydash import get
-from utils import collection_args, find_data_type_by_name, gql_args, \
-    unique_args
 
 
 BASE_URL = 'https://api.nolocolocal.io'

--- a/noloco/queries.py
+++ b/noloco/queries.py
@@ -1,6 +1,9 @@
-from constants import MANY_TO_ONE, ONE_TO_ONE
-from utils import build_data_type_args, build_operation_args, \
-    find_data_type_by_name, find_field_by_name
+from noloco.constants import MANY_TO_ONE, ONE_TO_ONE
+from noloco.utils import (
+    build_data_type_args,
+    build_operation_args,
+    find_data_type_by_name,
+    find_field_by_name)
 
 
 PROJECT_API_KEYS_QUERY = '''query ($projectId: String!) {

--- a/noloco/utils.py
+++ b/noloco/utils.py
@@ -1,6 +1,8 @@
-from constants import DATE, DECIMAL, INTEGER, TEXT
-from exceptions import NolocoDataTypeNotFoundError, NolocoFieldNotFoundError, \
-    NolocoFieldNotUniqueError
+from noloco.constants import DATE, DECIMAL, INTEGER, TEXT
+from noloco.exceptions import (
+    NolocoDataTypeNotFoundError,
+    NolocoFieldNotFoundError,
+    NolocoFieldNotUniqueError)
 from pydash import find, pascal_case
 
 


### PR DESCRIPTION
I was trying to get unit tests set up and ran into an issue where imports were not functioning as expected. It turns out this is due to Python 3 import semantics, we either need relative imports or absolute imports for internal imports. I am using absolute imports as it will group our imports together alphabetically.

I also went through and tidied up multi-line imports.

---
cc @noloco-io/engineering 