### PR TITLE
chore: adds some unit test coverage for utils and configures tests in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,7 @@
-.PHONY: docs
+.PHONY: tests docs
+
+tests:
+	python -m unittest
 
 docs:
 	rm -rf ./docs/_build

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,77 @@
+from noloco.utils import (
+    build_data_type_arg,
+    build_data_type_args,
+    build_operation_arg,
+    build_operation_args)
+from unittest import TestCase
+
+
+class TestBuildDataTypeArg(TestCase):
+    def test_build_data_type_arg_builds_arg_from_name(self):
+        arg_name = 'a'
+
+        built_arg = build_data_type_arg(arg_name)
+
+        self.assertEqual('a: $a', built_arg)
+
+
+class TestBuildDataTypeArgs(TestCase):
+    def test_build_data_type_args_builds_no_args(self):
+        args = {}
+
+        built_args = build_data_type_args(args)
+
+        self.assertEqual('', built_args)
+
+    def test_build_data_type_args_builds_single_arg(self):
+        args = {}
+        args['a'] = {'type': 'String', 'value': 'b'}
+
+        built_args = build_data_type_args(args)
+
+        self.assertEqual('(a: $a)', built_args)
+
+    def test_build_data_type_args_builds_multiple_arg(self):
+        args = {}
+        args['a'] = {'type': 'String', 'value': 'b'}
+        args['c'] = {'type': 'Int', 'value': 'd'}
+
+        built_args = build_data_type_args(args)
+
+        self.assertEqual('(a: $a, c: $c)', built_args)
+
+
+class TestBuildOperationArg(TestCase):
+    def test_build_operation_arg_builds_arg_from_name_and_type(self):
+        arg_name = 'a'
+        arg_value = {'type': 'String', 'value': 'b'}
+
+        built_arg = build_operation_arg(arg_name, arg_value)
+
+        self.assertEqual('$a: String', built_arg)
+
+
+class TestBuildOperationArgs(TestCase):
+    def test_build_operation_args_builds_no_args(self):
+        args = {}
+
+        built_args = build_operation_args(args)
+
+        self.assertEqual('', built_args)
+
+    def test_build_operation_args_builds_single_arg(self):
+        args = {}
+        args['a'] = {'type': 'String', 'value': 'b'}
+
+        built_args = build_operation_args(args)
+
+        self.assertEqual('($a: String)', built_args)
+
+    def test_build_operation_args_builds_multiple_arg(self):
+        args = {}
+        args['a'] = {'type': 'String', 'value': 'b'}
+        args['c'] = {'type': 'Int', 'value': 'd'}
+
+        built_args = build_operation_args(args)
+
+        self.assertEqual('($a: String, $c: Int)', built_args)


### PR DESCRIPTION
Before diving too deep into coding I want to get some basic test coverage of the utils we'll lean on heavily in the project. Additionally this let me check our packaging + testing is all working correctly.

`make tests` will run tests.

No CI is set up yet.

---
cc @noloco-io/engineering 