### PR TITLE
fix: adds support for reverse collection relationships in include

### DIFF
--- a/noloco/queries.py
+++ b/noloco/queries.py
@@ -102,12 +102,13 @@ class QueryBuilder:
         query_args = build_operation_args(args)
         data_type_args = build_data_type_args(args)
 
-        query_fragment = self.fields_builder.build_data_type_collection_fields(
+        query_fragment = self.fields_builder.build_fields(
             data_type['name'] + 'Collection',
             data_type,
             data_types,
             include,
-            data_type_args)
+            data_type_args,
+            is_collection=True)
         query = DATA_TYPE_COLLECTION_QUERY.format(
             query_args=query_args,
             data_type_collection_fragment=query_fragment)
@@ -118,7 +119,7 @@ class QueryBuilder:
         query_args = build_operation_args(args)
         data_type_args = build_data_type_args(args)
 
-        query_fragment = self.fields_builder.build_data_type_fields(
+        query_fragment = self.fields_builder.build_fields(
             data_type['name'],
             data_type,
             data_types,

--- a/noloco/utils.py
+++ b/noloco/utils.py
@@ -74,10 +74,7 @@ def find_field_by_name(field_name, fields):
         fields,
         lambda data_type_field: data_type_field['name'] == field_name)
 
-    if field is None:
-        raise NolocoFieldNotFoundError(field_name)
-    else:
-        return field
+    return field
 
 
 def gql_args(args):


### PR DESCRIPTION
Right now the `include` parameter works only for fields that the parent data type has; so for forward relationships. This means that this would work:

```
# user data type
include: {
  company: True
}
```

But this would not:

```
# user data type
include: {
  company: {
    include: {
      usersCollection: True
    }
  }
}
```

Because the `usersCollection` field does not exist on the `company` data type.

The simple solution to this is when we cannot find an included field on the data type, we need to search other data types for a reverse relationship and then use the data type that we find from that.

I think we could improve this along with the data type caching proposal by pre-processing that and building a reverse lookup dictionary.

---
cc @noloco-io/engineering 