### PR TITLE
chore: adds test coverage for MutationBuilder.build_data_type_mutation_args

### DIFF
--- a/noloco/mutations.py
+++ b/noloco/mutations.py
@@ -1,7 +1,7 @@
 from noloco.exceptions import NolocoFieldNotFoundError, NolocoUnknownError
 from noloco.fields import DataTypeFieldsBuilder
 from noloco.utils import build_data_type_args, build_operation_args, gql_type
-from pydash import get, pascal_case
+from pydash import find, get, pascal_case
 
 
 DATA_TYPE_MUTATION = '''mutation{mutation_args} {{
@@ -22,7 +22,7 @@ class MutationBuilder:
                 for field
                 in data_type['fields']
                 if field['name'] == arg_name]
-            data_type_field = data_type_fields[0]
+            data_type_field = find(data_type_fields)
 
             if data_type_field is not None:
                 # The field is either a top-level or relationship field on the

--- a/tests/test_mutations.py
+++ b/tests/test_mutations.py
@@ -1,0 +1,85 @@
+from noloco.constants import MANY_TO_ONE, ONE_TO_ONE
+from noloco.mutations import MutationBuilder
+from unittest import TestCase
+
+
+class TestBuildDataTypeMutationArgs(TestCase):
+    def setUp(self):
+        self.__mutation_builder = MutationBuilder()
+
+    def test_top_level_field(self):
+        data_type = {
+            'fields': [
+                {'name': 'a', 'type': 'TEXT', 'relationship': None}
+            ]
+        }
+        data_types = [data_type]
+        args = {'a': 'b'}
+
+        mutation_args = self.__mutation_builder.build_data_type_mutation_args(
+            data_type,
+            data_types,
+            args)
+
+        self.assertEqual(
+            {'a': {'type': 'String', 'value': 'b'}},
+            mutation_args)
+
+    def test_forward_relationship_field(self):
+        data_type = {
+            'fields': [
+                {'name': 'a', 'type': 'A', 'relationship': MANY_TO_ONE}
+            ]
+        }
+        data_types = [data_type]
+        args = {'a': {'connect': {'id': 1}}}
+
+        mutation_args = self.__mutation_builder.build_data_type_mutation_args(
+            data_type,
+            data_types,
+            args)
+
+        self.assertEqual(
+            {'aId': {'type': 'ID', 'value': 1}},
+            mutation_args)
+
+    def test_file_field(self):
+        data_type = {
+            'fields': [
+                {'name': 'a', 'type': 'file', 'relationship': ONE_TO_ONE}
+            ]
+        }
+        data_types = [data_type]
+        args = {'a': 'b'}
+
+        mutation_args = self.__mutation_builder.build_data_type_mutation_args(
+            data_type,
+            data_types,
+            args)
+
+        self.assertEqual(
+            {'a': {'type': 'Upload', 'value': 'b'}},
+            mutation_args)
+
+    def test_reverse_relationship_field(self):
+        data_type = {
+            'type': 'data_type_1',
+            'fields': []
+        }
+        related_data_type = {
+            'type': 'data_type_2',
+            'fields': [
+                {'name': 'b', 'reverseName': 'a', 'type': 'data_type_1', 'relationship': MANY_TO_ONE}
+            ]
+        }
+        data_types = [data_type, related_data_type]
+        args = {'a': [1, 2, 3]}
+
+        mutation_args = self.__mutation_builder.build_data_type_mutation_args(
+            data_type,
+            data_types,
+            args)
+
+        self.assertEqual(
+            {'aId': {'type': '[ID!]', 'value': [1, 2, 3]}},
+            mutation_args)


### PR DESCRIPTION
Adds some test coverage to one of the more critical pieces of business logic. Just simple cases for now but enables TDD in the future when debugging / refactoring in this code.

Also fixes a `KeyError` bug that could appear.

---
cc: @noloco-io/engineering 