### PR TITLE
fix: removes CSV export endpoint + cleans up imports + fixes setup.py linting

### DIFF
--- a/noloco/client.py
+++ b/noloco/client.py
@@ -19,7 +19,9 @@ from noloco.utils import (
     flatten_args,
     gql_args,
     has_files)
-from pydash import get, pascal_case
+from pydash import (
+    get,
+    pascal_case)
 
 
 BASE_URL = 'https://api.nolocolocal.io'
@@ -234,44 +236,6 @@ class Noloco:
             Result.unwrap(data_type_name, raw_result),
             options,
             self)
-
-    def export_csv(
-            self,
-            data_type_name,
-            after=None,
-            before=None,
-            first=None,
-            order_by=None,
-            where=None):
-        """Exports the members of a collection meeting the criteria you
-            specified to a base64 string.
-
-        Args:
-            data_type_name: The name of the data type the collection is for.
-                For example 'user'.
-            after: The cursor to paginate results after.
-            before: The cursor to paginate results before.
-            first: The number of results to paginate to.
-            order_by: The order to sort results in. For example:
-
-                { 'direction': 'ASC', field: 'createdAt' }
-            where: The filter that you would like to apply to the collection.
-                For example:
-
-                { 'roleId': { 'equals': 2 } }
-
-        Returns:
-            The base64 encoded string result of querying the Noloco collection
-            and exporting it as a CSV.
-        """
-        args = annotate_collection_args(
-            data_type_name, after, before, first, order_by, where)
-
-        query = self.__query_builder \
-            .build_data_type_collection_csv_export_query(data_type_name, args)
-
-        return self.__project_client.execute(
-            gql(query), variable_values=gql_args(args))
 
     def find(self, data_type_name, options={}):
         """Searches a Noloco collection for records matching the provided

--- a/noloco/fields.py
+++ b/noloco/fields.py
@@ -1,4 +1,7 @@
-from noloco.constants import MANY_TO_MANY, MANY_TO_ONE, ONE_TO_ONE
+from noloco.constants import (
+    MANY_TO_MANY,
+    MANY_TO_ONE,
+    ONE_TO_ONE)
 from noloco.utils import (
     build_data_type_args,
     find_field_by_name,

--- a/noloco/mutations.py
+++ b/noloco/mutations.py
@@ -1,7 +1,14 @@
-from noloco.exceptions import NolocoFieldNotFoundError, NolocoUnknownError
+from noloco.exceptions import (
+    NolocoFieldNotFoundError,
+    NolocoUnknownError)
 from noloco.fields import DataTypeFieldsBuilder
-from noloco.utils import build_data_type_args, build_operation_args, gql_type
-from pydash import find, get, pascal_case
+from noloco.utils import (
+    build_operation_args,
+    gql_type)
+from pydash import (
+    find,
+    get,
+    pascal_case)
 
 
 DATA_TYPE_MUTATION = '''mutation{mutation_args} {{

--- a/noloco/queries.py
+++ b/noloco/queries.py
@@ -1,7 +1,5 @@
 from noloco.fields import DataTypeFieldsBuilder
-from noloco.utils import (
-  build_data_type_args,
-  build_operation_args)
+from noloco.utils import build_operation_args
 
 
 PROJECT_API_KEYS_QUERY = '''query ($projectId: String!) {
@@ -69,13 +67,6 @@ DATA_TYPE_QUERY = '''query{query_args} {{
 }}'''
 
 
-DATA_TYPE_COLLECTION_CSV_EXPORT_QUERY = '''query{query_args} {{
-  {data_type_name}CsvExport{data_type_args} {{
-    base64
-  }}
-}}'''
-
-
 DATA_TYPE_COLLECTION_QUERY = '''query{query_args} {{
   {data_type_collection_fragment}
 }}'''
@@ -84,18 +75,6 @@ DATA_TYPE_COLLECTION_QUERY = '''query{query_args} {{
 class QueryBuilder:
     def __init__(self):
         self.fields_builder = DataTypeFieldsBuilder()
-
-    def build_data_type_collection_csv_export_query(
-            self, data_type, flattened_options):
-        query_args = build_operation_args(flattened_options)
-        data_type_args = build_data_type_args(flattened_options)
-
-        query = DATA_TYPE_COLLECTION_CSV_EXPORT_QUERY.format(
-            query_args=query_args,
-            data_type_name=data_type['name'],
-            data_type_args=data_type_args)
-
-        return query
 
     def build_data_type_collection_query(
             self, data_type, data_types, options, flattened_options):

--- a/noloco/utils.py
+++ b/noloco/utils.py
@@ -5,9 +5,11 @@ from noloco.constants import (
     DURATION,
     INTEGER,
     TEXT)
-from noloco.exceptions import (
-    NolocoDataTypeNotFoundError)
-from pydash import find, get, pascal_case
+from noloco.exceptions import NolocoDataTypeNotFoundError
+from pydash import (
+    find,
+    get,
+    pascal_case)
 
 
 def annotate_collection_args(data_type, data_types, args):

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,6 @@
-from setuptools import setup, find_packages
+from setuptools import (
+    setup,
+    find_packages)
 
 
 setup(

--- a/tests/test_mutations.py
+++ b/tests/test_mutations.py
@@ -1,4 +1,6 @@
-from noloco.constants import MANY_TO_ONE, ONE_TO_ONE
+from noloco.constants import (
+    MANY_TO_ONE,
+    ONE_TO_ONE)
 from noloco.mutations import MutationBuilder
 from unittest import TestCase
 


### PR DESCRIPTION
Cleaning up the code base now the larger features are all landed ahead of testing it. I'm removing CSV export for now so we just have the 5 CRUD endpoints. It's all in git so we can easily add it back but sounds like it isn't the focus right now and want to keep the code to exactly what we want to deliver without bloat. Also at this point looking at testing it'll be easier if we aren't supporting unneeded endpoints...

---
cc: @noloco-io/engineering 