### PR TITLE
fix: subtypes dict in Result to get pretty printing for free

### DIFF
--- a/noloco/results.py
+++ b/noloco/results.py
@@ -19,6 +19,9 @@ class Result(dict):
     def __getattr__(self, attr):
         return self[attr]
 
+    def __setattr__(self, attr, value):
+        self[attr] = value
+
     @staticmethod
     def traverse(data_type_name, result, options, client):
         if get(result, 'edges') is not None:


### PR DESCRIPTION
It turns out that because our `Result` type is so close to a dictionary type, Python actually provides some cool functionality if we inherit it from `dict`.

If we do this then direct accesses to fields still work as they did by us wrapping `Result` around them:

```
$ print(noloco.get('company', {
    'where': {
        'id': {
            'equals': 1
        }
    }
}).uuid)

rec3rthw63phl09rpayr
```

But where before we lost the advantage of pretty printing dictionaries we got back:

```
$ print(noloco.get('company', {
    'where': {
        'id': {
            'equals': 1
        }
    }
}))

<noloco.results.Result object at 0x1063bf160>
```

We now can do this again and get the advantages of working with the best of both worlds!

```
$ print(noloco.get('company', {
    'where': {
        'id': {
            'equals': 1
        }
    }
}))

{'id': '1', 'uuid': 'rec3rthw63phl09rpayr', 'createdAt': '2022-03-02T16:22:51.842Z', 'updatedAt': None, 'name': 'Example company', 'website': 'example.com', 'googleDriveFolderId': None, 'logo': None}
```

---
cc: @noloco-io/engineering 