### PR TITLE
fix: refactors how and where we do the result unwrapping

### DIFF
--- a/noloco/client.py
+++ b/noloco/client.py
@@ -173,9 +173,9 @@ class Noloco:
             variable_values=gql_args(flattened_options),
             upload_files=has_files(mutation_args))
 
-        return Result.traverse(
+        return Result.build(
             data_type_name,
-            Result.unwrap(data_type_name, raw_result),
+            raw_result,
             options,
             self)
 
@@ -231,9 +231,9 @@ class Noloco:
         raw_result = self.__project_client.execute(
             gql(mutation), variable_values=gql_args(flattened_options))
 
-        return Result.traverse(
+        return Result.build(
             data_type_name,
-            Result.unwrap(data_type_name, raw_result),
+            raw_result,
             options,
             self)
 
@@ -294,9 +294,9 @@ class Noloco:
             gql(query),
             variable_values=gql_args(flattened_options))
 
-        return Result.traverse(
-            data_type_name,
-            Result.unwrap(data_type_name + 'Collection', raw_result),
+        return Result.build(
+            data_type_name + 'Collection',
+            raw_result,
             options,
             self)
 
@@ -351,9 +351,9 @@ class Noloco:
         raw_result = self.__project_client.execute(
             gql(query), variable_values=gql_args(flattened_options))
 
-        return Result.traverse(
+        return Result.build(
             data_type_name,
-            Result.unwrap(data_type_name, raw_result),
+            raw_result,
             options,
             self)
 
@@ -435,8 +435,8 @@ class Noloco:
             variable_values=gql_args(flattened_options),
             upload_files=has_files(mutation_args))
 
-        return Result.traverse(
+        return Result.build(
             data_type_name,
-            Result.unwrap(data_type_name, raw_result),
+            raw_result,
             options,
             self)

--- a/noloco/fields.py
+++ b/noloco/fields.py
@@ -27,6 +27,7 @@ DATA_TYPE_COLLECTION_FIELDS = '''{data_type_name}{data_type_args} {{
       startCursor
       endCursor
     }}
+    __typename
   }}
 '''
 
@@ -131,7 +132,7 @@ class DataTypeFieldsBuilder:
 
         all_field_names = primary_field_schema + \
             related_field_schema + \
-            file_field_schema
+            file_field_schema + ['__typename']
 
         return '\n'.join(all_field_names)
 


### PR DESCRIPTION
This code review changes how and where we unwrap the top level result we got back from GraphQL. Previously we unwrapped it and then built the result objects, whereas now I am building the result objects and then unwrapping. This fixes a bug and also makes the initial call of `Result` identical to subsequent calls with the same `options` structure, whereas previous they were different.

I realise that nested pagination does not work correctly right now and will be fixing this in my next PR.

---
cc @noloco-io/engineering 