### PR TITLE
chore: adds test coverage reporting to Python SDK

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,8 @@
 .PHONY: tests docs
 
 tests:
-	python -m unittest
+	coverage run -m unittest discover
+	coverage report
 
 docs:
 	rm -rf ./docs/_build

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 autopep8
+coverage
 gql[all]
 pycodestyle
 pydash


### PR DESCRIPTION
I don't want to over-index on test coverage as its not particularly useful but I'm pulling in `coverage` just because being able to run `coverage html` to visualise the paths I'm hitting on the more complex business logic is actually really helpful.

---
cc: @noloco-io/engineering 