### PR TITLE
chore: integrates CI with test.pypi.org

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,3 +29,8 @@ jobs:
     - name: check PyPI artifacts
       run: |
         twine check dist/*
+    - name: check test.PyPI.org accepts the artifacts
+      uses: pypa/gh-action-pypi-publish@master
+      with:
+        password: ${{ secrets.TEST_PYPI_API_TOKEN }}
+        repository_url: https://test.pypi.org/legacy/


### PR DESCRIPTION
This PR extends the Github action where we build our PyPI artifacts by actually checking if test.pypi.org accepts the artifacts or not. This will give us an extra validation step where we know PRs are not breaking the SDK and it is always release-able.

---
cc: @noloco-io/engineering 