### PR TITLE
chore: bump version: 0.1.1 → 0.2.0

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.1.1
+current_version = 0.2.0
 commit = True
 tag = False
 

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import (
 
 setup(
     name='noloco',
-    version='0.1.1',
+    version='0.2.0',
     description='CRUD operations for Noloco Collections',
     long_description=open('README.md').read(),
     long_description_content_type='text/markdown',


### PR DESCRIPTION
v0.1.1 had some debugging code including a test API key in `client.py` accidentally committed and pushed. I'll remove the version from PyPI and republish but we cannot use the version number again so changing it to a minor version bump to keep the history clean.

---
cc: @noloco-io/engineering 