### PR TITLE
fix: single option GQL types and documents field type mapping

### DIFF
--- a/README.md
+++ b/README.md
@@ -268,3 +268,44 @@ Finally, if you know the ID of a record in a collection then you can delete it f
 ```
 client.delete('book', 1)
 ```
+
+## Field types
+
+You can use the following table to reference the mapping from Noloco field types onto Python types. For fields that are Python strings requiring a specific format, the format we expect is given here.
+
+| Noloco Field Type | Python Type | Expected Formats           |
+|-------------------|-------------|----------------------------|
+| Boolean           | bool        |                            |
+| Date              | str         | 'YYYY-MM-DDTHH:MM:SS.XXXZ' |
+| Decimal           | float       |                            |
+| Duration          | str         | 'HH:MM:SS'                 |
+| File/Upload       | (see below) |                            |
+| Integer           | int         |                            |
+| Single Option     | str         | 'SCREAMING_SNAKE_CASE'     |
+| Text              | str         |                            |
+
+### Files
+
+Note that unlike other the types, files have a different Python type depending on whether they are being given as an input or an output.
+
+When you are inputting a file to the SDK to be uploaded, you need to give the SDK an opened file, for example:
+
+```
+profile_picture = open('/Users/user/Pictures/profile_picture.jpeg', 'rb')
+```
+
+You will need to manage the closing of this file yourself after the SDK is done with it.
+
+When the SDK is outputting a file to you, it will give you a dictionary with information about the file:
+
+```
+{
+    'id': '...',
+    'uuid': '...',
+    'fileType': 'IMAGE',
+    'url': 'https://app-media.noloco.app/[project-name]/...profile_picture.jpeg',
+    'name': '%2FUsers%2Fuser%2FPictures%2Fprofile_picture.jpeg'
+}
+```
+
+You can use the URL to download the file if you need the contents.

--- a/noloco/mutations.py
+++ b/noloco/mutations.py
@@ -39,7 +39,7 @@ class MutationBuilder:
                     # This is a top-level field, so map the arg onto a
                     # primitive.
                     mutation_args[arg_name] = {
-                        'type': gql_type(data_type_field['type']),
+                        'type': gql_type(data_type, data_type_field),
                         'value': arg_value
                     }
                 elif get(arg_value, 'connect') is not None:
@@ -93,7 +93,7 @@ class MutationBuilder:
         mutation_args = build_operation_args(flattened_options)
 
         mutation_fragment = self.fields_builder.build_fields(
-            mutation + pascal_case(data_type['name']),
+            mutation + pascal_case(data_type['name'], strict=False),
             data_type,
             data_types,
             options)

--- a/noloco/requests.py
+++ b/noloco/requests.py
@@ -63,7 +63,8 @@ class Command:
 
     def mutate(self, mutation):
         self.mutation = mutation
-        self.result_name = mutation + pascal_case(self.data_type_name)
+        self.result_name = mutation + pascal_case(
+            self.data_type_name, strict=False)
         return self
 
     def query(self, query_type):


### PR DESCRIPTION
This change documents the Python type to Noloco type mapping, including the expected format of strings for certain fields (date/duration/select fields).

It fixed an issue where we could return single option selects but not upsert them as they were missing from `gql_type`.

Additionally I'm working around an issue with `pydash` where `pascal_case('testObject')` would return `'Testobject'` rather than `'TestObject'`. To get the expected result we need to add `strict=False` to the invocation.

---
Testing

Creating a record with duration, date and single option fields:
```
>>> obj = client.create('testObject', {'data': {'durationField': '1:02:03', 'dateTimeField': '2022-01-01T00:00:00.000Z', 'singleOptionSelectField': 'OPTION_C'}})
>>> print(obj)
{'id': '2', 'uuid': 'rec3vm4vj2qcl0trt1gx', 'createdAt': '2022-03-16T16:21:09.681Z', 'updatedAt': None, 'durationField': '1:02:03', 'dateTimeField': '2022-01-01T00:00:00.000Z', 'singleOptionSelectField': 'OPTION_C', '__typename': 'TestObject'}
```

Filtering on single options:
```
>>> objs = client.findMany('testObject', {
...     'where': {
...         'singleOptionSelectField': {
...             'equals': 'OPTION_C'
...         }
...     }
... })
>>> print(objs)
{'total_count': 1, 'has_previous_page': False, 'has_next_page': False, 'data': [{'id': '2', 'uuid': 'rec3vm4vj2qcl0trt1gx', 'createdAt': '2022-03-16T16:21:09.681Z', 'updatedAt': None, 'durationField': '1:02:03', 'dateTimeField': '2022-01-01T00:00:00.000Z', 'singleOptionSelectField': 'OPTION_C', '__typename': 'TestObject'}]}
```

---
cc: @noloco-io/engineering 