### PR TITLE
fix: enables multi-file uploads

### DIFF
--- a/noloco/fields.py
+++ b/noloco/fields.py
@@ -35,11 +35,19 @@ DATA_TYPE_COLLECTION_FIELDS = '''{data_type_name}{data_type_args} {{
 FILE_FIELDS = '''id uuid fileType url name'''
 
 
-FILE_CONNECTION_FIELDS = '''edges {{
+FILE_CONNECTION_FIELDS = '''totalCount
+edges {{
   node {{
     {file_query}
   }}
-}}'''.format(file_query=FILE_FIELDS)
+}}
+pageInfo {{
+  hasPreviousPage
+  hasNextPage
+  startCursor
+  endCursor
+}}
+__typename'''.format(file_query=FILE_FIELDS)
 
 
 class DataTypeFieldsBuilder:

--- a/noloco/mutations.py
+++ b/noloco/mutations.py
@@ -1,3 +1,4 @@
+from noloco.constants import MANY_TO_MANY, ONE_TO_ONE
 from noloco.exceptions import (
     NolocoFieldNotFoundError,
     NolocoUnknownError)
@@ -55,10 +56,16 @@ class MutationBuilder:
                     # This is a file upload field, so map the arg onto an
                     # Upload arg, although do not open the file yet.
                     # TODO - stronger validation and error handling.
-                    mutation_args[arg_name] = {
-                        'type': 'Upload',
-                        'value': arg_value
-                    }
+                    if data_type_field['relationship'] == MANY_TO_MANY:
+                        mutation_args[arg_name] = {
+                            'type': '[Upload!]',
+                            'value': arg_value
+                        }
+                    else:
+                        mutation_args[arg_name] = {
+                            'type': 'Upload',
+                            'value': arg_value
+                        }
                 else:
                     raise NolocoUnknownError()
             else:

--- a/noloco/utils.py
+++ b/noloco/utils.py
@@ -202,7 +202,7 @@ def gql_type(data_type, data_type_field):
 
 def has_files(args):
     for arg_value in args.values():
-        if arg_value['type'] == 'Upload':
+        if 'Upload' in arg_value['type']:
             return True
 
     return False


### PR DESCRIPTION
The current implementation of the SDK was not handling multi-file uploads correctly. I fix this here.

To differentiate between single and multi-file uploads I'm checking the `relationship` property on a field and assume that multi-file fields have `MANY_TO_MANY` and single file fields have `ONE_TO_ONE`.

I simply need to adjust the type on multi uploads to be `[Upload!]` and make sure that `has_files` detects this type when setting the `upload_files` flag. Other than that GQL handles everything for us.

---
**Testing**

Uploading multiple files now works:
```
>>> f1 = open("/Users/matt/Pictures/profile.jpeg", 'rb')
>>> f2 = open("/Users/matt/Pictures/profile2.jpeg", 'rb')
>>> res = client.create('airtableTable2', {'data': {'attachments': [f1, f2]}})
>>> print(res)
{'id': '5', 'uuid': 'recX7hXYDjfStFKy3', 'createdAt': '2022-03-16T17:30:14.000Z', 'updatedAt': None, 'name': None, 'notes': None, 'status': None, 'attachments': <noloco.results.CollectionResult object at 0x106c0b2e0>, '__typename': 'AirtableTable2'}
```

![image](https://user-images.githubusercontent.com/6977616/158652596-09ae5e53-d5cd-4658-9edd-1304cb0e5e6d.png)

Uploading single files still works:
```
>>> f1 = open("/Users/matt/Pictures/profile.jpeg", 'rb')
>>> client.create('user', {'data': {'profilePicture': f1}})
{'id': '4', 'uuid': 'recever2qyl0tubigo', 'createdAt': '2022-03-16T17:31:30.744Z', 'updatedAt': None, 'email': None, 'firstName': None, 'lastName': None, 'isInternal': False, 'invitationToken': None, 'isActive': True, 'profilePicture': {'id': '9', 'uuid': 'a2581dc7-d00d-476c-8fbc-bca3e868d698', 'fileType': 'IMAGE', 'url': 'https://app-media.noloco.app/matt-test-env/a2581dc7-d00d-476c-8fbc-bca3e868d698-%252FUsers%252Fmatt%252FPictures%252Fprofile.jpeg', 'name': '%2FUsers%2Fmatt%2FPictures%2Fprofile.jpeg'}, '__typename': 'User'}
```

![image](https://user-images.githubusercontent.com/6977616/158652730-c00bb435-934a-4802-a4cb-f9d2665e52b9.png)

---
cc: @noloco-io/engineering 