### PR TITLE
fix: mapping to GQL type for multi-option selects

### DIFF
--- a/README.md
+++ b/README.md
@@ -281,6 +281,7 @@ You can use the following table to reference the mapping from Noloco field types
 | Duration          | str         | 'HH:MM:SS'                 |
 | File/Upload       | (see below) |                            |
 | Integer           | int         |                            |
+| Multiple Option   | list        | ['SCREAMING_SNAKE_CASE']   |
 | Single Option     | str         | 'SCREAMING_SNAKE_CASE'     |
 | Text              | str         |                            |
 

--- a/noloco/constants.py
+++ b/noloco/constants.py
@@ -24,6 +24,9 @@ BOOLEAN = 'BOOLEAN'
 SINGLE_OPTION = 'SINGLE_OPTION'
 
 
+MULTIPLE_OPTION = 'MULTIPLE_OPTION'
+
+
 ###############################################################################
 # Relationship Types
 ###############################################################################

--- a/noloco/utils.py
+++ b/noloco/utils.py
@@ -4,6 +4,7 @@ from noloco.constants import (
     DECIMAL,
     DURATION,
     INTEGER,
+    MULTIPLE_OPTION,
     SINGLE_OPTION,
     TEXT)
 from noloco.exceptions import (
@@ -198,6 +199,10 @@ def gql_type(data_type, data_type_field):
     elif field_type == SINGLE_OPTION:
         return pascal_case(data_type['name'], strict=False) + \
             pascal_case(data_type_field['name'], strict=False)
+    elif field_type == MULTIPLE_OPTION:
+        enum_prefix = pascal_case(data_type['name'], strict=False)
+        enum_suffix = pascal_case(data_type_field['name'], strict=False)
+        return f'[{enum_prefix}{enum_suffix}!]'
 
 
 def has_files(args):


### PR DESCRIPTION
Similar to the fix for single option selects, this just makes sure that multiple option selects get mapped to the correct GQL type so that they can be upserted and queried with.

---
**Testing**

Can upsert a multi select field:
```
>>> res = client.create('airtableTable2', {'data': {'multiStatus': ['OPTION_B', 'OPTION_C']}})
>>> print(res)
{'id': '6', 'uuid': 'recLzcxLbEE1q2VOM', 'createdAt': '2022-03-16T18:06:03.000Z', 'updatedAt': None, 'name': None, 'notes': None, 'status': None, 'multiStatus': ['OPTION_B', 'OPTION_C'], 'attachments': <noloco.results.CollectionResult object at 0x10432df10>, '__typename': 'AirtableTable2'}
```

Can filter on multi select fields:
```
>>> res = client.findMany('airtableTable2', {'where': {'multiStatus': {'in': 'OPTION_B'}}})
>>> print(res)
{'total_count': 2, 'has_previous_page': False, 'has_next_page': False, 'data': [{'id': '6', 'uuid': 'recLzcxLbEE1q2VOM', 'createdAt': '2022-03-16T18:06:03.000Z', 'updatedAt': None, 'name': None, 'notes': None, 'status': None, 'multiStatus': ['OPTION_B', 'OPTION_C'], 'attachments': <noloco.results.CollectionResult object at 0x104373d00>, '__typename': 'AirtableTable2'}, {'id': '5', 'uuid': 'recX7hXYDjfStFKy3', 'createdAt': '2022-03-16T17:30:14.000Z', 'updatedAt': '2022-03-16T18:05:40.586Z', 'name': None, 'notes': None, 'status': None, 'multiStatus': ['OPTION_A', 'OPTION_B'], 'attachments': <noloco.results.CollectionResult object at 0x104373eb0>, '__typename': 'AirtableTable2'}]}
>>> res = client.findMany('airtableTable2', {'where': {'multiStatus': {'in': 'OPTION_A'}}})
>>> print(res)
{'total_count': 1, 'has_previous_page': False, 'has_next_page': False, 'data': [{'id': '5', 'uuid': 'recX7hXYDjfStFKy3', 'createdAt': '2022-03-16T17:30:14.000Z', 'updatedAt': '2022-03-16T18:05:40.586Z', 'name': None, 'notes': None, 'status': None, 'multiStatus': ['OPTION_A', 'OPTION_B'], 'attachments': <noloco.results.CollectionResult object at 0x10435a130>, '__typename': 'AirtableTable2'}]}
```

---
cc: @noloco-io/engineering 