### PR TITLE
chore: bump version: 0.3.0 → 0.4.0

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.3.0
+current_version = 0.4.0
 commit = True
 tag = False
 

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import (
 
 setup(
     name='noloco',
-    version='0.3.0',
+    version='0.4.0',
     description='CRUD operations for Noloco Collections',
     long_description=open('README.md').read(),
     long_description_content_type='text/markdown',


### PR DESCRIPTION
Bumping a minor version rather than patch as we do technically have a non-breaking feature in this release (override API host name).

---
cc: @noloco-io/engineering 