### PR TITLE
fix: splits out core and project base URLs in client setup

### DIFF
--- a/noloco/client.py
+++ b/noloco/client.py
@@ -5,20 +5,30 @@ from noloco.requests import Command
 from noloco.utils import options_without_data
 
 
-BASE_URL = 'https://api.portals.noloco.io'
+CORE_BASE_URL = 'https://api.core.noloco.io'
+PROJECT_BASE_URL = 'https://api.portals.noloco.io'
 
 
 class Noloco:
-    def __init__(self, account_api_key, portal_name, base_url=BASE_URL):
+    def __init__(
+        self,
+        account_api_key,
+        portal_name,
+        core_base_url=CORE_BASE_URL,
+        project_base_url=PROJECT_BASE_URL
+    ):
         """Initialises a Noloco client.
 
         Args:
             account_api_key: The Account API Key from your Integrations & API
                 Keys settings page.
             portal_name: The name of your Noloco portal.
-            base_url: The URL that the API is hosted at. This is an optional
-                parameter and if you are using the production API you should
-                not provide it.
+            core_base_url: The URL that the core API is hosted at. This is an
+                optional parameter and if you are using the production API you
+                should not provide it.
+            project_base_url: The URL that the project API is hosted at. This
+                is an optional parameter and if you are using the production
+                API you should not provide it.
 
         Returns:
             A Noloco client.
@@ -31,14 +41,14 @@ class Noloco:
         # Build the account client that will be used to interact with the
         # project document.
         account_transport = AIOHTTPTransport(
-            url=base_url, headers={'Authorization': account_api_key})
+            url=core_base_url, headers={'Authorization': account_api_key})
         account_client = Client(
             transport=account_transport,
             fetch_schema_from_transport=False)
 
         # Fetch the project document, lookup and validate the project API key
         # and cache the data types locally.
-        self.__project = Project(account_client, base_url, portal_name)
+        self.__project = Project(account_client, project_base_url, portal_name)
 
     def create(self, data_type_name, options):
         """Creates a record in a Noloco collection.


### PR DESCRIPTION
This updates our Python SDK to choose between the core and project APIs based on the type of queries it is making. It will perform the project query to lookup and validate API keys against the core API and then revert back to using the project API for all CRUD operations.